### PR TITLE
Enable Monte Carlo path tracing with Russian roulette

### DIFF
--- a/Assets/lilToon/SoftwareRayTracing/RayGenerator.cs
+++ b/Assets/lilToon/SoftwareRayTracing/RayGenerator.cs
@@ -11,14 +11,14 @@ namespace lilToon.RayTracing
         /// Create a ray going through a pixel on the screen.
         /// </summary>
         /// <param name="camera">Camera used for generating the ray.</param>
-        /// <param name="x">Pixel x coordinate.</param>
-        /// <param name="y">Pixel y coordinate.</param>
+        /// <param name="x">Pixel x coordinate with subpixel offset.</param>
+        /// <param name="y">Pixel y coordinate with subpixel offset.</param>
         /// <param name="width">Screen width in pixels.</param>
         /// <param name="height">Screen height in pixels.</param>
-        public static Ray Generate(Camera camera, int x, int y, int width, int height)
+        public static Ray Generate(Camera camera, float x, float y, int width, int height)
         {
-            float u = (x + 0.5f) / width;
-            float v = (y + 0.5f) / height;
+            float u = x / width;
+            float v = y / height;
             return camera.ViewportPointToRay(new Vector3(u, v, 0f));
         }
     }

--- a/Assets/lilToon/SoftwareRayTracing/RayTracingRenderer.cs
+++ b/Assets/lilToon/SoftwareRayTracing/RayTracingRenderer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace lilToon.RayTracing
@@ -15,6 +14,7 @@ namespace lilToon.RayTracing
         public GameObject sceneRoot;
         public int width = 256;
         public int height = 256;
+        public int samples = 16;
 
         Texture2D _output;
         List<BvhBuilder.BvhNode> _nodes;
@@ -61,15 +61,21 @@ namespace lilToon.RayTracing
                 return;
 
             var colors = new Color[width * height];
-            Parallel.For(0, height, y =>
+            for (int y = 0; y < height; ++y)
             {
                 for (int x = 0; x < width; ++x)
                 {
-                    Ray ray = RayGenerator.Generate(targetCamera, x, y, width, height);
-                    Color col = Shading.Shade(ray, _nodes, _triangles, _lights);
-                    colors[y * width + x] = col;
+                    Color col = Color.black;
+                    for (int s = 0; s < samples; ++s)
+                    {
+                        float u = x + Random.value;
+                        float v = y + Random.value;
+                        Ray ray = RayGenerator.Generate(targetCamera, u, v, width, height);
+                        col += Shading.Shade(ray, _nodes, _triangles, _lights);
+                    }
+                    colors[y * width + x] = col / samples;
                 }
-            });
+            }
             _output.SetPixels(colors);
             _output.Apply();
             Shader.SetGlobalTexture("_lilSoftwareRayTex", _output);

--- a/Assets/lilToon/SoftwareRayTracing/Shading.cs
+++ b/Assets/lilToon/SoftwareRayTracing/Shading.cs
@@ -4,29 +4,77 @@ using UnityEngine;
 namespace lilToon.RayTracing
 {
     /// <summary>
-    /// Shading routine that fetches material parameters and computes
-    /// direct lighting with shadows and simple reflections.
+    /// Path tracing shader evaluation with Monte Carlo integration.
+    /// Samples the BRDF at each bounce, accumulates radiance and
+    /// terminates paths using Russian roulette.
     /// </summary>
     public static class Shading
     {
-        const int MaxDepth = 2;
         const int AreaLightSamples = 4;
+        const int MaxDepth = 8;
+        const int RussianRouletteDepth = 3;
 
         /// <summary>
-        /// Shades a raycast hit using a simple BRDF and recursive reflections.
+        /// Evaluate the incoming radiance along a ray using Monte Carlo
+        /// path tracing. Lights are sampled explicitly and indirect
+        /// illumination is gathered by recursively sampling the BRDF.
         /// </summary>
-        public static Color Shade(Ray ray,
+        public static Color Shade(
+            Ray ray,
             List<BvhBuilder.BvhNode> nodes,
             List<BvhBuilder.Triangle> triangles,
-            List<LightCollector.LightData> lights,
-            int depth = 0)
+            List<LightCollector.LightData> lights)
         {
-            if (depth > MaxDepth ||
-                !Raycaster.Raycast(ray, nodes, triangles, out float dist, out int triIndex))
-                return Color.black;
+            Color radiance = Color.black;
+            Color throughput = Color.white;
+            Ray currentRay = ray;
 
-            var tri = triangles[triIndex];
-            Vector3 hitPos = ray.origin + ray.direction * dist;
+            for (int depth = 0; depth < MaxDepth; depth++)
+            {
+                if (!Raycaster.Raycast(currentRay, nodes, triangles, out float dist, out int triIndex))
+                    break;
+
+                var tri = triangles[triIndex];
+                Vector3 hitPos = currentRay.origin + currentRay.direction * dist;
+                Vector3 normal = tri.normal;
+                Vector3 viewDir = -currentRay.direction;
+
+                // Direct lighting
+                Color direct = SampleLights(tri.material, normal, viewDir, hitPos, nodes, triangles, lights);
+                radiance += throughput * direct;
+
+                // Russian roulette termination
+                if (depth >= RussianRouletteDepth)
+                {
+                    float q = Mathf.Max(throughput.r, Mathf.Max(throughput.g, throughput.b));
+                    q = Mathf.Clamp01(q);
+                    if (Random.value > q)
+                        break;
+                    throughput /= Mathf.Max(q, 1e-3f);
+                }
+
+                // Sample next direction from BRDF
+                Vector3 newDir = SampleBrdf(tri.material, normal, viewDir, out Color brdf, out float pdf);
+                float ndotd = Mathf.Max(0f, Vector3.Dot(newDir, normal));
+                if (pdf <= 0f || ndotd <= 0f)
+                    break;
+
+                throughput *= brdf * ndotd / pdf;
+                currentRay = new Ray(hitPos + newDir * 1e-3f, newDir);
+            }
+
+            return radiance;
+        }
+
+        static Color SampleLights(
+            LilToonParameters mat,
+            Vector3 normal,
+            Vector3 viewDir,
+            Vector3 hitPos,
+            List<BvhBuilder.BvhNode> nodes,
+            List<BvhBuilder.Triangle> triangles,
+            List<LightCollector.LightData> lights)
+        {
             Color result = Color.black;
 
             foreach (var light in lights)
@@ -44,7 +92,7 @@ namespace lilToon.RayTracing
                             shadowDist < lightDistance)
                             continue;
 
-                        Color brdf = EvaluateBrdf(tri.material, tri.normal, lightDir, -ray.direction);
+                        Color brdf = EvaluateBrdf(mat, normal, lightDir, viewDir);
                         result += brdf * light.color * light.intensity;
                         break;
                     }
@@ -55,7 +103,7 @@ namespace lilToon.RayTracing
                         if (Raycaster.Raycast(shadowRay, nodes, triangles, out _, out _))
                             continue;
 
-                        Color brdf = EvaluateBrdf(tri.material, tri.normal, lightDir, -ray.direction);
+                        Color brdf = EvaluateBrdf(mat, normal, lightDir, viewDir);
                         result += brdf * light.color * light.intensity;
                         break;
                     }
@@ -75,7 +123,7 @@ namespace lilToon.RayTracing
                             shadowDist < lightDistance)
                             continue;
 
-                        Color brdf = EvaluateBrdf(tri.material, tri.normal, lightDir, -ray.direction);
+                        Color brdf = EvaluateBrdf(mat, normal, lightDir, viewDir);
                         result += brdf * light.color * light.intensity * cosAngle;
                         break;
                     }
@@ -99,7 +147,7 @@ namespace lilToon.RayTracing
                                 shadowDist < lightDistance)
                                 continue;
 
-                            Color brdf = EvaluateBrdf(tri.material, tri.normal, lightDir, -ray.direction);
+                            Color brdf = EvaluateBrdf(mat, normal, lightDir, viewDir);
                             contrib += brdf * light.color * light.intensity;
                         }
 
@@ -109,20 +157,50 @@ namespace lilToon.RayTracing
                 }
             }
 
-            if (depth < MaxDepth)
-            {
-                Vector3 reflectDir = Vector3.Reflect(ray.direction, tri.normal).normalized;
-                Ray reflectRay = new Ray(hitPos + reflectDir * 1e-3f, reflectDir);
-                Color reflected = Shade(reflectRay, nodes, triangles, lights, depth + 1);
-
-                float fresnel = tri.material.metallic +
-                                (1f - tri.material.metallic) *
-                                Mathf.Pow(1f - Mathf.Max(0f, Vector3.Dot(-ray.direction, tri.normal)), 5f);
-                float reflectivity = (1f - tri.material.roughness) * fresnel;
-                result += reflected * reflectivity;
-            }
-
             return result;
+        }
+
+        static Vector3 SampleBrdf(
+            LilToonParameters mat,
+            Vector3 normal,
+            Vector3 viewDir,
+            out Color brdf,
+            out float pdf)
+        {
+            float metallic = mat.metallic;
+            if (Random.value < metallic)
+            {
+                // Perfect mirror reflection
+                Vector3 dir = Vector3.Reflect(-viewDir, normal).normalized;
+                brdf = Color.white * metallic;
+                pdf = Mathf.Max(metallic, 1e-3f);
+                return dir;
+            }
+            else
+            {
+                // Cosine-weighted diffuse reflection
+                Vector3 dir = SampleHemisphere(normal);
+                float cos = Mathf.Max(0f, Vector3.Dot(dir, normal));
+                brdf = mat.color * (1f - metallic) / Mathf.PI;
+                pdf = cos * (1f - metallic) / Mathf.PI;
+                return dir;
+            }
+        }
+
+        static Vector3 SampleHemisphere(Vector3 normal)
+        {
+            float u1 = Random.value;
+            float u2 = Random.value;
+            float r = Mathf.Sqrt(u1);
+            float theta = 2f * Mathf.PI * u2;
+            float x = r * Mathf.Cos(theta);
+            float y = r * Mathf.Sin(theta);
+            float z = Mathf.Sqrt(1f - u1);
+
+            // Build orthonormal basis
+            Vector3 tangent = Vector3.Normalize(Vector3.Cross(normal, Mathf.Abs(normal.x) > 0.1f ? Vector3.up : Vector3.right));
+            Vector3 bitangent = Vector3.Cross(normal, tangent);
+            return (x * tangent + y * bitangent + z * normal).normalized;
         }
 
         static Color EvaluateBrdf(LilToonParameters mat, Vector3 normal, Vector3 lightDir, Vector3 viewDir)
@@ -139,3 +217,4 @@ namespace lilToon.RayTracing
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- Convert shading to an iterative Monte Carlo path tracer with BRDF sampling and Russian roulette termination
- Average multiple jittered samples per pixel in `RayTracingRenderer`
- Allow subpixel ray generation for stochastic sampling

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*
- `cd Assets/lilToon && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68abd027302083299f2d5a40e131f2ec