### PR TITLE
Add jittered multi-sample ray tracing with accumulation

### DIFF
--- a/Assets/lilToon/SoftwareRayTracing/RayGenerator.cs
+++ b/Assets/lilToon/SoftwareRayTracing/RayGenerator.cs
@@ -15,10 +15,11 @@ namespace lilToon.RayTracing
         /// <param name="y">Pixel y coordinate.</param>
         /// <param name="width">Screen width in pixels.</param>
         /// <param name="height">Screen height in pixels.</param>
-        public static Ray Generate(Camera camera, int x, int y, int width, int height)
+        /// <param name="pixelOffset">Random sub-pixel offset.</param>
+        public static Ray Generate(Camera camera, int x, int y, int width, int height, Vector2 pixelOffset)
         {
-            float u = (x + 0.5f) / width;
-            float v = (y + 0.5f) / height;
+            float u = (x + pixelOffset.x) / width;
+            float v = (y + pixelOffset.y) / height;
             return camera.ViewportPointToRay(new Vector3(u, v, 0f));
         }
     }

--- a/Assets/lilToon/SoftwareRayTracing/RayTracingRenderer.cs
+++ b/Assets/lilToon/SoftwareRayTracing/RayTracingRenderer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -15,8 +16,11 @@ namespace lilToon.RayTracing
         public GameObject sceneRoot;
         public int width = 256;
         public int height = 256;
+        public int samplesPerPixel = 1;
 
         Texture2D _output;
+        Color[] _accumulation;
+        int _frameCount;
         List<BvhBuilder.BvhNode> _nodes;
         List<BvhBuilder.Triangle> _triangles;
         List<LightCollector.LightData> _lights;
@@ -39,6 +43,9 @@ namespace lilToon.RayTracing
                 _output = new Texture2D(width, height, TextureFormat.RGBA32, false);
                 _output.wrapMode = TextureWrapMode.Clamp;
                 Shader.SetGlobalTexture("_lilSoftwareRayTex", _output);
+
+                _accumulation = new Color[width * height];
+                _frameCount = 0;
             }
         }
 
@@ -60,16 +67,33 @@ namespace lilToon.RayTracing
             if (targetCamera == null || _nodes == null)
                 return;
 
+            if (_accumulation == null || _accumulation.Length != width * height)
+            {
+                _accumulation = new Color[width * height];
+                _frameCount = 0;
+            }
+
             var colors = new Color[width * height];
+            int frameIndex = _frameCount + 1;
             Parallel.For(0, height, y =>
             {
                 for (int x = 0; x < width; ++x)
                 {
-                    Ray ray = RayGenerator.Generate(targetCamera, x, y, width, height);
-                    Color col = Shading.Shade(ray, _nodes, _triangles, _lights);
-                    colors[y * width + x] = col;
+                    var rng = new Random(x * 73856093 ^ y * 19349663 ^ frameIndex);
+                    Color col = Color.black;
+                    for (int s = 0; s < samplesPerPixel; ++s)
+                    {
+                        var offset = new Vector2((float)rng.NextDouble(), (float)rng.NextDouble());
+                        Ray ray = RayGenerator.Generate(targetCamera, x, y, width, height, offset);
+                        col += Shading.Shade(ray, _nodes, _triangles, _lights);
+                    }
+                    col /= samplesPerPixel;
+                    int idx = y * width + x;
+                    _accumulation[idx] += col;
+                    colors[idx] = _accumulation[idx] / frameIndex;
                 }
             });
+            _frameCount = frameIndex;
             _output.SetPixels(colors);
             _output.Apply();
             Shader.SetGlobalTexture("_lilSoftwareRayTex", _output);


### PR DESCRIPTION
## Summary
- allow sub-pixel jitter in ray generation
- shoot multiple rays per pixel and average results
- accumulate rendering across frames for progressive refinement

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68abd038aa5083299a6d12e566da2301