### PR TITLE
Add texture references and PBR shading

### DIFF
--- a/Assets/lilToon/SoftwareRayTracing/BvhBuilder.cs
+++ b/Assets/lilToon/SoftwareRayTracing/BvhBuilder.cs
@@ -14,7 +14,15 @@ namespace lilToon.RayTracing
             public Vector3 v0;
             public Vector3 v1;
             public Vector3 v2;
-            public Vector3 normal;
+            public Vector3 n0;
+            public Vector3 n1;
+            public Vector3 n2;
+            public Vector4 t0;
+            public Vector4 t1;
+            public Vector4 t2;
+            public Vector2 uv0;
+            public Vector2 uv1;
+            public Vector2 uv2;
             public LilToonParameters material;
         }
 
@@ -140,19 +148,46 @@ namespace lilToon.RayTracing
         {
             var tris = new List<Triangle>();
             var verts = mesh.vertices;
+            var norms = mesh.normals;
+            var tans = mesh.tangents;
+            var uvs = mesh.uvs;
             var indices = mesh.indices;
             Matrix4x4 m = mesh.localToWorld;
             for (int i = 0; i < indices.Length; i += 3)
             {
-                Vector3 v0 = m.MultiplyPoint3x4(verts[indices[i]]);
-                Vector3 v1 = m.MultiplyPoint3x4(verts[indices[i + 1]]);
-                Vector3 v2 = m.MultiplyPoint3x4(verts[indices[i + 2]]);
+                int i0 = indices[i];
+                int i1 = indices[i + 1];
+                int i2 = indices[i + 2];
+                Vector3 v0 = m.MultiplyPoint3x4(verts[i0]);
+                Vector3 v1 = m.MultiplyPoint3x4(verts[i1]);
+                Vector3 v2 = m.MultiplyPoint3x4(verts[i2]);
+
+                Vector3 n0 = m.MultiplyVector(norms[i0]).normalized;
+                Vector3 n1 = m.MultiplyVector(norms[i1]).normalized;
+                Vector3 n2 = m.MultiplyVector(norms[i2]).normalized;
+
+                Vector4 tan0 = tans[i0];
+                Vector4 tan1 = tans[i1];
+                Vector4 tan2 = tans[i2];
+
+                Vector3 t0w = m.MultiplyVector(new Vector3(tan0.x, tan0.y, tan0.z)).normalized;
+                Vector3 t1w = m.MultiplyVector(new Vector3(tan1.x, tan1.y, tan1.z)).normalized;
+                Vector3 t2w = m.MultiplyVector(new Vector3(tan2.x, tan2.y, tan2.z)).normalized;
+
                 Triangle t = new Triangle
                 {
                     v0 = v0,
                     v1 = v1,
                     v2 = v2,
-                    normal = Vector3.Normalize(Vector3.Cross(v1 - v0, v2 - v0)),
+                    n0 = n0,
+                    n1 = n1,
+                    n2 = n2,
+                    t0 = new Vector4(t0w.x, t0w.y, t0w.z, tan0.w),
+                    t1 = new Vector4(t1w.x, t1w.y, t1w.z, tan1.w),
+                    t2 = new Vector4(t2w.x, t2w.y, t2w.z, tan2.w),
+                    uv0 = uvs[i0],
+                    uv1 = uvs[i1],
+                    uv2 = uvs[i2],
                     material = mesh.material
                 };
                 tris.Add(t);

--- a/Assets/lilToon/SoftwareRayTracing/GeometryCollector.cs
+++ b/Assets/lilToon/SoftwareRayTracing/GeometryCollector.cs
@@ -13,6 +13,7 @@ namespace lilToon.RayTracing
             public Vector3[] vertices;
             public Vector3[] normals;
             public Vector2[] uvs;
+            public Vector4[] tangents;
             public int[] indices;
             public LilToonParameters material;
             public Matrix4x4 localToWorld;
@@ -36,6 +37,7 @@ namespace lilToon.RayTracing
                     vertices = mesh.vertices,
                     normals = mesh.normals,
                     uvs = mesh.uv,
+                    tangents = mesh.tangents,
                     indices = mesh.triangles,
                     material = mat,
                     localToWorld = mf.transform.localToWorldMatrix
@@ -51,6 +53,7 @@ namespace lilToon.RayTracing
                     vertices = mesh.vertices,
                     normals = mesh.normals,
                     uvs = mesh.uv,
+                    tangents = mesh.tangents,
                     indices = mesh.triangles,
                     material = mat,
                     localToWorld = smr.transform.localToWorldMatrix

--- a/Assets/lilToon/SoftwareRayTracing/ParameterExtractor.cs
+++ b/Assets/lilToon/SoftwareRayTracing/ParameterExtractor.cs
@@ -11,6 +11,8 @@ namespace lilToon.RayTracing
         public Color color;
         public float metallic;
         public float roughness;
+        public Texture2D albedoMap;
+        public Texture2D normalMap;
     }
 
     public static class ParameterExtractor
@@ -28,6 +30,8 @@ namespace lilToon.RayTracing
             param.metallic = material.HasProperty("_Metallic") ? material.GetFloat("_Metallic") : 0f;
             // lilToon uses smoothness; convert to roughness for ray tracing.
             param.roughness = material.HasProperty("_Smoothness") ? 1f - material.GetFloat("_Smoothness") : 1f;
+            param.albedoMap = material.HasProperty("_MainTex") ? material.GetTexture("_MainTex") as Texture2D : null;
+            param.normalMap = material.HasProperty("_BumpMap") ? material.GetTexture("_BumpMap") as Texture2D : null;
             return param;
         }
     }

--- a/Assets/lilToon/SoftwareRayTracing/Shading.cs
+++ b/Assets/lilToon/SoftwareRayTracing/Shading.cs
@@ -27,6 +27,25 @@ namespace lilToon.RayTracing
 
             var tri = triangles[triIndex];
             Vector3 hitPos = ray.origin + ray.direction * dist;
+
+            Vector3 bary = Barycentric(hitPos, tri.v0, tri.v1, tri.v2);
+            Vector2 uv = tri.uv0 * bary.x + tri.uv1 * bary.y + tri.uv2 * bary.z;
+            Vector3 normal = (tri.n0 * bary.x + tri.n1 * bary.y + tri.n2 * bary.z).normalized;
+            Vector4 tan = tri.t0 * bary.x + tri.t1 * bary.y + tri.t2 * bary.z;
+            Vector3 tangent = new Vector3(tan.x, tan.y, tan.z).normalized;
+            Vector3 bitangent = Vector3.Cross(normal, tangent) * tan.w;
+
+            if (tri.material.normalMap != null)
+            {
+                Color ncol = tri.material.normalMap.GetPixelBilinear(uv.x, uv.y);
+                Vector3 nTangent = new Vector3(ncol.r * 2f - 1f, ncol.g * 2f - 1f, ncol.b * 2f - 1f);
+                normal = (tangent * nTangent.x + bitangent * nTangent.y + normal * nTangent.z).normalized;
+            }
+
+            Color albedo = tri.material.color;
+            if (tri.material.albedoMap != null)
+                albedo *= tri.material.albedoMap.GetPixelBilinear(uv.x, uv.y);
+
             Color result = Color.black;
 
             foreach (var light in lights)
@@ -44,7 +63,7 @@ namespace lilToon.RayTracing
                             shadowDist < lightDistance)
                             continue;
 
-                        Color brdf = EvaluateBrdf(tri.material, tri.normal, lightDir, -ray.direction);
+                        Color brdf = EvaluateBrdf(albedo, tri.material.metallic, tri.material.roughness, normal, lightDir, -ray.direction);
                         result += brdf * light.color * light.intensity;
                         break;
                     }
@@ -55,7 +74,7 @@ namespace lilToon.RayTracing
                         if (Raycaster.Raycast(shadowRay, nodes, triangles, out _, out _))
                             continue;
 
-                        Color brdf = EvaluateBrdf(tri.material, tri.normal, lightDir, -ray.direction);
+                        Color brdf = EvaluateBrdf(albedo, tri.material.metallic, tri.material.roughness, normal, lightDir, -ray.direction);
                         result += brdf * light.color * light.intensity;
                         break;
                     }
@@ -75,7 +94,7 @@ namespace lilToon.RayTracing
                             shadowDist < lightDistance)
                             continue;
 
-                        Color brdf = EvaluateBrdf(tri.material, tri.normal, lightDir, -ray.direction);
+                        Color brdf = EvaluateBrdf(albedo, tri.material.metallic, tri.material.roughness, normal, lightDir, -ray.direction);
                         result += brdf * light.color * light.intensity * cosAngle;
                         break;
                     }
@@ -99,7 +118,7 @@ namespace lilToon.RayTracing
                                 shadowDist < lightDistance)
                                 continue;
 
-                            Color brdf = EvaluateBrdf(tri.material, tri.normal, lightDir, -ray.direction);
+                            Color brdf = EvaluateBrdf(albedo, tri.material.metallic, tri.material.roughness, normal, lightDir, -ray.direction);
                             contrib += brdf * light.color * light.intensity;
                         }
 
@@ -111,13 +130,13 @@ namespace lilToon.RayTracing
 
             if (depth < MaxDepth)
             {
-                Vector3 reflectDir = Vector3.Reflect(ray.direction, tri.normal).normalized;
+                Vector3 reflectDir = Vector3.Reflect(ray.direction, normal).normalized;
                 Ray reflectRay = new Ray(hitPos + reflectDir * 1e-3f, reflectDir);
                 Color reflected = Shade(reflectRay, nodes, triangles, lights, depth + 1);
 
                 float fresnel = tri.material.metallic +
                                 (1f - tri.material.metallic) *
-                                Mathf.Pow(1f - Mathf.Max(0f, Vector3.Dot(-ray.direction, tri.normal)), 5f);
+                                Mathf.Pow(1f - Mathf.Max(0f, Vector3.Dot(-ray.direction, normal)), 5f);
                 float reflectivity = (1f - tri.material.roughness) * fresnel;
                 result += reflected * reflectivity;
             }
@@ -125,17 +144,48 @@ namespace lilToon.RayTracing
             return result;
         }
 
-        static Color EvaluateBrdf(LilToonParameters mat, Vector3 normal, Vector3 lightDir, Vector3 viewDir)
+        static Color EvaluateBrdf(Color albedo, float metallic, float roughness, Vector3 normal, Vector3 lightDir, Vector3 viewDir)
         {
-            float ndotl = Mathf.Max(0f, Vector3.Dot(normal, lightDir));
-            Color diffuse = mat.color * ndotl * (1f - mat.metallic);
-
             Vector3 halfDir = (lightDir + viewDir).normalized;
-            float ndoth = Mathf.Max(0f, Vector3.Dot(normal, halfDir));
-            float shininess = Mathf.Lerp(1f, 256f, 1f - mat.roughness);
-            Color spec = Color.white * mat.metallic * Mathf.Pow(ndoth, shininess);
 
-            return diffuse + spec;
+            float ndotl = Mathf.Max(0f, Vector3.Dot(normal, lightDir));
+            float ndotv = Mathf.Max(0f, Vector3.Dot(normal, viewDir));
+            float ndoth = Mathf.Max(0f, Vector3.Dot(normal, halfDir));
+            float vdoth = Mathf.Max(0f, Vector3.Dot(viewDir, halfDir));
+
+            float a = roughness * roughness;
+            float a2 = a * a;
+            float denom = ndoth * ndoth * (a2 - 1f) + 1f;
+            float D = a2 / (Mathf.PI * denom * denom + 1e-7f);
+
+            float k = (roughness + 1f);
+            k = (k * k) / 8f;
+            float Gv = ndotv / (ndotv * (1f - k) + k);
+            float Gl = ndotl / (ndotl * (1f - k) + k);
+            float G = Gv * Gl;
+
+            Color F0 = Color.Lerp(new Color(0.04f, 0.04f, 0.04f, 1f), albedo, metallic);
+            Color F = F0 + (Color.white - F0) * Mathf.Pow(1f - vdoth, 5f);
+
+            Color spec = F * (D * G / (4f * ndotv * ndotl + 1e-5f));
+            Color diffuse = (albedo / Mathf.PI) * (1f - metallic);
+
+            return (diffuse + spec) * ndotl;
+        }
+
+        static Vector3 Barycentric(Vector3 p, Vector3 a, Vector3 b, Vector3 c)
+        {
+            Vector3 v0 = b - a, v1 = c - a, v2 = p - a;
+            float d00 = Vector3.Dot(v0, v0);
+            float d01 = Vector3.Dot(v0, v1);
+            float d11 = Vector3.Dot(v1, v1);
+            float d20 = Vector3.Dot(v2, v0);
+            float d21 = Vector3.Dot(v2, v1);
+            float denom = d00 * d11 - d01 * d01;
+            float v = (d11 * d20 - d01 * d21) / denom;
+            float w = (d00 * d21 - d01 * d20) / denom;
+            float u = 1f - v - w;
+            return new Vector3(u, v, w);
         }
     }
 }


### PR DESCRIPTION
## Summary
- capture albedo and normal textures in `LilToonParameters`
- record tangents and UVs per triangle for normal mapping
- switch BRDF to GGX with Schlick Fresnel and Smith geometry while sampling textures

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abd0c012888329a28bb6facdfa7ece