### PR TITLE
Add GPU raycasting compute shader

### DIFF
--- a/Assets/lilToon/SoftwareRayTracing/RayTracing.compute
+++ b/Assets/lilToon/SoftwareRayTracing/RayTracing.compute
@@ -1,0 +1,69 @@
+#pragma kernel CSMain
+
+struct Triangle
+{
+    float3 v0; float pad0;
+    float3 v1; float pad1;
+    float3 v2; float pad2;
+    float3 n0; float pad3;
+    float3 n1; float pad4;
+    float3 n2; float pad5;
+    int materialIndex; float3 pad6;
+};
+
+struct Material
+{
+    float3 color; float pad;
+};
+
+StructuredBuffer<Triangle> _Triangles;
+StructuredBuffer<Material> _Materials;
+int _NumTriangles;
+float3 _CameraPos;
+float3 _CameraForward;
+float3 _CameraRight;
+float3 _CameraUp;
+float _TanFov;
+float _Aspect;
+
+RWTexture2D<float4> Result;
+
+[numthreads(8,8,1)]
+void CSMain(uint3 id : SV_DispatchThreadID)
+{
+    uint width, height;
+    Result.GetDimensions(width, height);
+    if (id.x >= width || id.y >= height) return;
+
+    float u = ((id.x + 0.5) / width - 0.5) * 2.0;
+    float v = ((id.y + 0.5) / height - 0.5) * 2.0;
+    float3 dir = normalize(_CameraForward + _CameraRight * (u * _TanFov * _Aspect) + _CameraUp * (v * _TanFov));
+    float minDist = 1e20;
+    float3 col = float3(0,0,0);
+    for (int i = 0; i < _NumTriangles; i++)
+    {
+        Triangle t = _Triangles[i];
+        float3 edge1 = t.v1 - t.v0;
+        float3 edge2 = t.v2 - t.v0;
+        float3 pvec = cross(dir, edge2);
+        float det = dot(edge1, pvec);
+        if (abs(det) < 1e-8) continue;
+        float invDet = 1.0 / det;
+        float3 tvec = _CameraPos - t.v0;
+        float utri = dot(tvec, pvec) * invDet;
+        if (utri < 0 || utri > 1) continue;
+        float3 qvec = cross(tvec, edge1);
+        float vtri = dot(dir, qvec) * invDet;
+        if (vtri < 0 || utri + vtri > 1) continue;
+        float dist = dot(edge2, qvec) * invDet;
+        if (dist > 0 && dist < minDist)
+        {
+            minDist = dist;
+            float w = 1.0 - utri - vtri;
+            float3 n = normalize(t.n0 * w + t.n1 * utri + t.n2 * vtri);
+            float3 baseCol = _Materials[t.materialIndex].color;
+            col = baseCol * saturate(n.y);
+        }
+    }
+    Result[id.xy] = float4(col, 1.0);
+}

--- a/Assets/lilToon/SoftwareRayTracing/RayTracing.compute.meta
+++ b/Assets/lilToon/SoftwareRayTracing/RayTracing.compute.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 5b3e0d9df2e34f78ba1b8fcd58a3c4c2
+ComputeShaderImporter:
+  externalObjects: {}
+  preprocess: 
+  shaderVariantMode: 0
+  shaderVariantLogLevel: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/lilToon/SoftwareRayTracing/RayTracingRenderer.cs
+++ b/Assets/lilToon/SoftwareRayTracing/RayTracingRenderer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using UnityEngine;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace lilToon.RayTracing
 {
@@ -24,7 +25,10 @@ namespace lilToon.RayTracing
         public string environmentPath;
 
 
-        Texture2D _output;
+        public ComputeShader rayTracingShader;
+
+        RenderTexture _output;
+        Texture2D _cpuTexture;
         SpectralColor[] _accumulation;
         int _frameCount;
         List<BvhBuilder.BvhNode> _nodes;
@@ -39,6 +43,28 @@ namespace lilToon.RayTracing
         Color[] _colorBuffer;
         System.Random[] _rngs;
 
+        ComputeBuffer _triangleBuffer;
+        ComputeBuffer _materialBuffer;
+        int _kernel;
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct GpuTriangle
+        {
+            public Vector3 v0; public float pad0;
+            public Vector3 v1; public float pad1;
+            public Vector3 v2; public float pad2;
+            public Vector3 n0; public float pad3;
+            public Vector3 n1; public float pad4;
+            public Vector3 n2; public float pad5;
+            public int materialIndex; public Vector3 pad6;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct GpuMaterial
+        {
+            public Vector3 color; public float pad;
+        }
+
         void OnEnable()
         {
             if (targetCamera == null)
@@ -49,19 +75,36 @@ namespace lilToon.RayTracing
             BuildScene();
             LoadEnvironment();
             InitTexture();
+            if (rayTracingShader != null)
+                _kernel = rayTracingShader.FindKernel("CSMain");
         }
 
         void OnDisable()
         {
             if (_output != null)
             {
-                DestroyImmediate(_output);
+                _output.Release();
                 _output = null;
+            }
+            if (_cpuTexture != null)
+            {
+                DestroyImmediate(_cpuTexture);
+                _cpuTexture = null;
             }
             if (_environment != null)
             {
                 DestroyImmediate(_environment);
                 _environment = null;
+            }
+            if (_triangleBuffer != null)
+            {
+                _triangleBuffer.Release();
+                _triangleBuffer = null;
+            }
+            if (_materialBuffer != null)
+            {
+                _materialBuffer.Release();
+                _materialBuffer = null;
             }
             _environmentPixels = null;
             _nodes = null;
@@ -85,9 +128,19 @@ namespace lilToon.RayTracing
         {
             if (_output == null || _output.width != width || _output.height != height)
             {
-                _output = new Texture2D(width, height, TextureFormat.RGBA32, false);
-                _output.wrapMode = TextureWrapMode.Clamp;
-                Shader.SetGlobalTexture("_lilSoftwareRayTex", _output);
+                if (_output != null)
+                    _output.Release();
+                _output = new RenderTexture(width, height, 0, RenderTextureFormat.ARGBFloat)
+                {
+                    enableRandomWrite = true,
+                    wrapMode = TextureWrapMode.Clamp
+                };
+                _output.Create();
+
+                _cpuTexture = new Texture2D(width, height, TextureFormat.RGBA32, false)
+                {
+                    wrapMode = TextureWrapMode.Clamp
+                };
 
                 _accumulation = new SpectralColor[width * height];
                 _frameCount = 0;
@@ -99,6 +152,7 @@ namespace lilToon.RayTracing
             var meshes = GeometryCollector.Collect(sceneRoot);
             _nodes = BvhBuilder.Build(meshes, out _triangles, out _materials);
             _lights = LightCollector.Collect(sceneRoot);
+            UpdateComputeBuffers();
         }
 
         async void LoadEnvironment()
@@ -129,10 +183,85 @@ namespace lilToon.RayTracing
             Render();
         }
 
+        void UpdateComputeBuffers()
+        {
+            if (rayTracingShader == null)
+                return;
+
+            if (_triangleBuffer != null)
+            {
+                _triangleBuffer.Release();
+                _triangleBuffer = null;
+            }
+            if (_materialBuffer != null)
+            {
+                _materialBuffer.Release();
+                _materialBuffer = null;
+            }
+
+            if (_triangles != null && _triangles.Count > 0)
+            {
+                var gpuTris = new GpuTriangle[_triangles.Count];
+                for (int i = 0; i < _triangles.Count; i++)
+                {
+                    var t = _triangles[i];
+                    gpuTris[i] = new GpuTriangle
+                    {
+                        v0 = t.v0,
+                        v1 = t.v1,
+                        v2 = t.v2,
+                        n0 = t.n0,
+                        n1 = t.n1,
+                        n2 = t.n2,
+                        materialIndex = t.materialIndex
+                    };
+                }
+                _triangleBuffer = new ComputeBuffer(gpuTris.Length, Marshal.SizeOf(typeof(GpuTriangle)));
+                _triangleBuffer.SetData(gpuTris);
+            }
+
+            if (_materials != null && _materials.Count > 0)
+            {
+                var gpuMats = new GpuMaterial[_materials.Count];
+                for (int i = 0; i < _materials.Count; i++)
+                {
+                    Color rgb = _materials[i].color.ToRGB();
+                    gpuMats[i] = new GpuMaterial { color = new Vector3(rgb.r, rgb.g, rgb.b) };
+                }
+                _materialBuffer = new ComputeBuffer(gpuMats.Length, Marshal.SizeOf(typeof(GpuMaterial)));
+                _materialBuffer.SetData(gpuMats);
+            }
+
+            if (rayTracingShader != null)
+            {
+                if (_triangleBuffer != null)
+                    rayTracingShader.SetBuffer(_kernel, "_Triangles", _triangleBuffer);
+                if (_materialBuffer != null)
+                    rayTracingShader.SetBuffer(_kernel, "_Materials", _materialBuffer);
+            }
+        }
+
         void Render()
         {
             if (targetCamera == null || _nodes == null)
                 return;
+
+            if (rayTracingShader != null)
+            {
+                rayTracingShader.SetInt("_NumTriangles", _triangles != null ? _triangles.Count : 0);
+                rayTracingShader.SetVector("_CameraPos", targetCamera.transform.position);
+                rayTracingShader.SetVector("_CameraForward", targetCamera.transform.forward);
+                rayTracingShader.SetVector("_CameraRight", targetCamera.transform.right);
+                rayTracingShader.SetVector("_CameraUp", targetCamera.transform.up);
+                rayTracingShader.SetFloat("_TanFov", Mathf.Tan(targetCamera.fieldOfView * Mathf.Deg2Rad * 0.5f));
+                rayTracingShader.SetFloat("_Aspect", (float)width / height);
+                rayTracingShader.SetTexture(_kernel, "Result", _output);
+                int tx = Mathf.CeilToInt(width / 8f);
+                int ty = Mathf.CeilToInt(height / 8f);
+                rayTracingShader.Dispatch(_kernel, tx, ty, 1);
+                Shader.SetGlobalTexture("_lilSoftwareRayTex", _output);
+                return;
+            }
 
             if (_accumulation == null || _accumulation.Length != width * height)
             {
@@ -149,8 +278,6 @@ namespace lilToon.RayTracing
                     _rngs[i] = new System.Random(i * 9973);
             }
 
-            // Capture camera parameters on the main thread to avoid
-            // accessing the Unity Camera API inside worker threads.
             var camParams = new RayGenerator.CameraParams
             {
                 position = targetCamera.transform.position,
@@ -182,9 +309,9 @@ namespace lilToon.RayTracing
                 }
             });
             _frameCount = frameIndex;
-            _output.SetPixels(colors);
-            _output.Apply();
-            Shader.SetGlobalTexture("_lilSoftwareRayTex", _output);
+            _cpuTexture.SetPixels(colors);
+            _cpuTexture.Apply();
+            Shader.SetGlobalTexture("_lilSoftwareRayTex", _cpuTexture);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add compute shader for GPU-based ray casting
- upload mesh data to compute buffers and dispatch GPU kernel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68abefc2b28c83298a940fadb936a50c