### PR TITLE
Enable ray tracing configuration in lilToon materials

### DIFF
--- a/Assets/lilToon/Editor/lilEnumeration.cs
+++ b/Assets/lilToon/Editor/lilEnumeration.cs
@@ -74,6 +74,7 @@ namespace lilToon
         Stencil,
         Rendering,
         Tessellation,
+        RayTracing,
         Other
     }
 

--- a/Assets/lilToon/Editor/lilInspector/lilEditorVariables.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilEditorVariables.cs
@@ -81,6 +81,7 @@ namespace lilToon
             public bool isShowRendering                 = false;
             public bool isShowLightBake                 = false;
             public bool isShowOptimization              = false;
+            public bool isShowRayTracing                = false;
             public bool isShowBlend                     = false;
             public bool isShowBlendAdd                  = false;
             public bool isShowBlendPre                  = false;

--- a/Assets/lilToon/Editor/lilInspector/lilMainInspectorGUI.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilMainInspectorGUI.cs
@@ -49,8 +49,30 @@ namespace lilToon
                         EditorGUILayout.EndVertical();
                         EditorGUILayout.EndVertical();
                     }
-                }
+        }
 
+        private void DrawRayTracingGUI(Material material)
+        {
+            GUILayout.Label("Ray Tracing", boldLabel);
+            edSet.isShowRayTracing = lilEditorGUI.Foldout("Ray Tracing", edSet.isShowRayTracing);
+            DrawMenuButton(string.Empty, PropertyBlock.RayTracing);
+            if(edSet.isShowRayTracing)
+            {
+                EditorGUILayout.BeginVertical(boxOuter);
+                EditorGUILayout.LabelField("Ray Tracing", customToggleFont);
+                EditorGUILayout.BeginVertical(boxInnerHalf);
+                bool enabled = material.GetFloat("_RayTracingEnable") > 0.5f;
+                EditorGUI.BeginChangeCheck();
+                enabled = EditorGUILayout.ToggleLeft("Enable Ray Tracing", enabled, customToggleFont);
+                if(EditorGUI.EndChangeCheck())
+                {
+                    foreach(var m in materials)
+                        m.SetFloat("_RayTracingEnable", enabled ? 1.0f : 0.0f);
+                }
+                EditorGUILayout.EndVertical();
+                EditorGUILayout.EndVertical();
+            }
+        }
                 //------------------------------------------------------------------------------------------------------------------------------
                 // VRChat
                 DrawVRCFallbackGUI(material);
@@ -293,6 +315,7 @@ namespace lilToon
                         EditorGUILayout.EndVertical();
                     }
                 }
+                DrawRayTracingGUI(material);
             }
             else if(isFakeShadow)
             {
@@ -541,6 +564,7 @@ namespace lilToon
                         EditorGUILayout.EndVertical();
                     }
                 }
+                DrawRayTracingGUI(material);
             }
             else
             {
@@ -1646,6 +1670,7 @@ namespace lilToon
                         EditorGUILayout.EndVertical();
                     }
                 }
+                DrawRayTracingGUI(material);
             }
         }
     }

--- a/Assets/lilToon/Editor/lilInspector/lilMaterialProperties.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilMaterialProperties.cs
@@ -619,6 +619,7 @@ namespace lilToon
         private readonly lilMaterialProperty triMask                = new lilMaterialProperty("_TriMask", true, PropertyBlock.Base);
         private readonly lilMaterialProperty matcapMul              = new lilMaterialProperty("_MatCapMul", PropertyBlock.MatCaps, PropertyBlock.MatCap1st);
         private readonly lilMaterialProperty fakeShadowVector       = new lilMaterialProperty("_FakeShadowVector", PropertyBlock.Base);
+        private readonly lilMaterialProperty rayTracing             = new lilMaterialProperty("_RayTracingEnable", PropertyBlock.RayTracing);
 
         private readonly lilMaterialProperty ramp = new lilMaterialProperty("_Ramp", true);
 
@@ -1227,6 +1228,7 @@ namespace lilToon
                 asOverlay,
                 triMask,
                 matcapMul,
+                rayTracing,
                 fakeShadowVector,
 
                 ramp,

--- a/Assets/lilToon/SoftwareRayTracing/RayTracingRenderer.cs
+++ b/Assets/lilToon/SoftwareRayTracing/RayTracingRenderer.cs
@@ -97,10 +97,12 @@ namespace lilToon.RayTracing
             InitTexture();
             if (rayTracingShader != null)
                 _kernel = rayTracingShader.FindKernel("CSMain");
+            Shader.SetGlobalInt("_lilSoftwareRayEnabled", 1);
         }
 
         void OnDisable()
         {
+            Shader.SetGlobalInt("_lilSoftwareRayEnabled", 0);
             if (_output != null)
             {
                 _output.Release();


### PR DESCRIPTION
## Summary
- add dedicated RayTracing property block and editor foldout
- expose a material toggle for ray tracing at the end of the inspector
- automatically toggle a global shader flag when the ray tracing renderer is active

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b85198ba348329be9d29e212f9ca5e