### PR TITLE
Overlay software ray tracing result in toon shader

### DIFF
--- a/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
@@ -2074,5 +2074,9 @@
 // Output
 #if !defined(OVERRIDE_OUTPUT)
     #define OVERRIDE_OUTPUT \
+        if(_lilSoftwareRayEnabled != 0) { \
+            float4 rayCol = LIL_SAMPLE_SCREEN(_lilSoftwareRayTex, lil_sampler_linear_clamp, fd.uvScn); \
+            fd.col.rgb = lerp(fd.col.rgb, rayCol.rgb, rayCol.a); \
+        } \
         return fd.col;
 #endif

--- a/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
@@ -43,6 +43,9 @@ SAMPLER(lil_sampler_linear_clamp);
     #define LIL_ENABLED_DEPTH_TEX IsScreenTex(_CameraDepthTexture)
 #endif
 
+TEXTURE2D_SCREEN(_lilSoftwareRayTex);
+uint _lilSoftwareRayEnabled;
+
 //------------------------------------------------------------------------------------------------------------------------------
 // Texture Exists
 #if !defined(LIL_FEATURE_MainTex)


### PR DESCRIPTION
## Summary
- Expose `_lilSoftwareRayTex` and `_lilSoftwareRayEnabled` to shaders
- Blend software ray tracing texture over final toon color

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b858cfd5dc832992aa841b5bcf558d